### PR TITLE
Add option to skip parsing underscores

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,5 +1,6 @@
 package stripmd
 
 type Options struct {
-	SkipImages bool
+	SkipImages      bool // Remove images link
+	SkipUnderscores bool // Skip parsing underscores
 }

--- a/strip.go
+++ b/strip.go
@@ -50,8 +50,10 @@ func StripOptions(s string, opts Options) string {
 
 	res = emphReg.ReplaceAllString(res, "$1")
 	res = emphReg2.ReplaceAllString(res, "$1")
-	res = emphReg3.ReplaceAllString(res, "$1")
-	res = emphReg4.ReplaceAllString(res, "$1")
+	if !opts.SkipUnderscores {
+		res = emphReg3.ReplaceAllString(res, "$1")
+		res = emphReg4.ReplaceAllString(res, "$1")
+	}
 	res = htmlReg.ReplaceAllString(res, "$1")
 	res = setextHeaderReg.ReplaceAllString(res, "")
 	res = footnotesReg.ReplaceAllString(res, "")

--- a/strip_test.go
+++ b/strip_test.go
@@ -111,6 +111,33 @@ You can even share code stuff.`
 	if res := Strip(in); res != out {
 		t.Errorf("Original:\n\n%s\n\nGot:\n\n%s", in, res)
 	}
+	// Test to skip images
+	in = "![Some image](https://write.as/favicon.ico)"
+	out = ""
+	if res := StripOptions(in, Options{SkipImages: true}); res != out {
+		t.Errorf("Original:\n\n%s\n\nGot:\n\n%s", in, res)
+	}
+
+	// Test for skipping single underscores
+	in = "_this is single emphasis_"
+	out = "_this is single emphasis_"
+	if res := StripOptions(in, Options{SkipUnderscores: true}); res != out {
+		t.Errorf("Original:\n\n%s\n\nGot:\n\n%s", in, res)
+	}
+	if res := Strip(in); res == out {
+		t.Errorf("Original:\n\n%s\n\nGot:\n\n%s", in, res)
+	}
+
+	// Test for skipping double underscores
+	in = "__this is double emphasis__"
+	out = "__this is double emphasis__"
+	if res := StripOptions(in, Options{SkipUnderscores: true}); res != out {
+		t.Errorf("Original:\n\n%s\n\nGot:\n\n%s", in, res)
+	}
+	if res := Strip(in); res == out {
+		t.Errorf("Original:\n\n%s\n\nGot:\n\n%s", in, res)
+	}
+
 }
 
 func ExampleStrip() {


### PR DESCRIPTION
Option to skip parsing underscores https://github.com/writeas/go-strip-markdown/issues/4

This is useful for users who do not use underscores in their markdown